### PR TITLE
Adds "Easy Apply" stage with LinkedIn icon

### DIFF
--- a/src/constants/availableStages.ts
+++ b/src/constants/availableStages.ts
@@ -1,12 +1,13 @@
 import {
+  Award,
   Briefcase,
+  Calendar,
+  DollarSign,
+  FileText,
+  Linkedin,
   Mail,
   Phone,
   Users,
-  FileText,
-  Calendar,
-  DollarSign,
-  Award,
   X,
 } from "lucide-react";
 import { Stage } from "../types/stages";
@@ -80,6 +81,14 @@ export const availableStages: Stage[] = [
     id: "rejection",
     name: "Rejection",
     icon: X,
+    position: null,
+    application_id: null,
+    auth_user: null,
+  },
+  {
+    id: "linkedin-easyapply",
+    name: "Easy Apply",
+    icon: Linkedin,
     position: null,
     application_id: null,
     auth_user: null,


### PR DESCRIPTION
Updates the available stages list to include a new stage called "Easy Apply" with an icon of the LinkedIn logo. This change allows users to easily identify and interact with the "Easy Apply" stage in the application process.

Relates to #33